### PR TITLE
Update Singularity.centos.def

### DIFF
--- a/Singularity.centos.def
+++ b/Singularity.centos.def
@@ -19,7 +19,6 @@ Include: yum wget
     mikado --help
 
 %environment
-	export MIKADO_COMMIT_HASH=$(cd /usr/local/src/mikado && git log | head -n 1 | cut -f 2 -d " ")
     export PATH="/usr/local/bin:$PATH:/usr/local/conda/bin/"
     # source /usr/local/conda/bin/activate
 


### PR DESCRIPTION
Removed unused environment variable MIKADO_COMMIT_HASH (that one does not work; the show_commit_hash script also does not rely on it)