### PR TITLE
Remove libmagic

### DIFF
--- a/Mikado/parsers/__init__.py
+++ b/Mikado/parsers/__init__.py
@@ -10,7 +10,7 @@ import abc
 import gzip
 import bz2
 from functools import partial
-import magic
+from ..utilities.file_type import filetype
 
 
 class HeaderError(Exception):
@@ -23,14 +23,12 @@ class HeaderError(Exception):
 class Parser(metaclass=abc.ABCMeta):
     """Generic parser iterator. Base parser class."""
 
-    wizard = magic.Magic(mime=True)
-
     def __init__(self, handle):
         self.__closed = False
         if not isinstance(handle, io.IOBase):
-            if handle.endswith(".gz") or self.wizard.from_file(handle) == b"application/gzip":
+            if handle.endswith(".gz") or filetype(handle) == b"application/gzip":
                 opener = gzip.open
-            elif handle.endswith(".bz2") or self.wizard.from_file(handle) == b"application/x-bzip2":
+            elif handle.endswith(".bz2") or filetype(handle) == b"application/x-bzip2":
                 opener = bz2.open
             else:
                 opener = partial(open, **{"buffering": 1})

--- a/Mikado/scales/compare.py
+++ b/Mikado/scales/compare.py
@@ -24,6 +24,7 @@ from ..parsers.GTF import GTF
 from ..parsers.bed12 import Bed12Parser
 from ..parsers.bam_parser import BamParser
 from ..parsers import to_gff
+from ..utilities.file_type import filetype
 from ..utilities.log_utils import create_default_logger, formatter
 import magic
 import sqlite3
@@ -686,9 +687,7 @@ def load_index(args, queue_logger):
     # genes, positions = None, None
 
     # New: now we are going to use SQLite for a faster experience
-    wizard = magic.Magic(mime=True)
-
-    if wizard.from_file("{0}.midx".format(args.reference.name)) == b"application/gzip":
+    if filetype("{0}.midx".format(args.reference.name)) == b"application/gzip":
         queue_logger.warning("Old index format detected. Starting to generate a new one.")
         raise CorruptIndex("Invalid index file")
 

--- a/Mikado/scales/gene_dict.py
+++ b/Mikado/scales/gene_dict.py
@@ -1,6 +1,7 @@
 from ..loci.reference_gene import Gene
 import magic
 from ..exceptions import CorruptIndex
+from ..utilities.file_type import filetype
 from ..utilities.log_utils import create_null_logger
 import sqlite3
 import json
@@ -108,14 +109,13 @@ class GeneDict:
 
 
 def check_index(reference, queue_logger):
-    wizard = magic.Magic(mime=True)
 
     if reference.endswith("midx"):
         reference = reference
     else:
         reference = "{}.midx".format(reference)
 
-    if wizard.from_file(reference) == b"application/gzip":
+    if filetype(reference) == b"application/gzip":
         queue_logger.warning("Old index format detected. Starting to generate a new one.")
         raise CorruptIndex("Invalid index file")
 

--- a/Mikado/utilities/file_type.py
+++ b/Mikado/utilities/file_type.py
@@ -1,18 +1,19 @@
 import sys
 
 magic_dict = {
-    "\x1f\x8b\x08": b"application/gzip",
-    "\x42\x5a\x68": b"application/x-bzip2",
-    "\x50\x4b\x03\x04": b"application/zip"
+    b"\x1f\x8b\x08": b"application/gzip",
+    b"\x42\x5a\x68": b"application/x-bzip2",
+    b"\x50\x4b\x03\x04": b"application/zip"
     }
+
 
 max_len = max(len(x) for x in magic_dict)
 
 
 def filetype(filename):
-    with open(filename) as f:
+    with open(filename, "rb") as f:
         file_start = f.read(max_len)
     for magic, ftype in magic_dict.items():
-        if file_start.startswith(magic):
+        if magic == file_start[:len(magic)]:
             return ftype
     return b"application/txt"

--- a/Mikado/utilities/file_type.py
+++ b/Mikado/utilities/file_type.py
@@ -14,6 +14,6 @@ def filetype(filename):
     with open(filename, "rb") as f:
         file_start = f.read(max_len)
     for magic, ftype in magic_dict.items():
-        if magic == file_start[:len(magic)]:
+        if file_start.startswith(magic):
             return ftype
     return b"application/txt"

--- a/Mikado/utilities/file_type.py
+++ b/Mikado/utilities/file_type.py
@@ -1,0 +1,18 @@
+import sys
+
+magic_dict = {
+    "\x1f\x8b\x08": b"application/gzip",
+    "\x42\x5a\x68": b"application/x-bzip2",
+    "\x50\x4b\x03\x04": b"application/zip"
+    }
+
+max_len = max(len(x) for x in magic_dict)
+
+
+def filetype(filename):
+    with open(filename) as f:
+        file_start = f.read(max_len)
+    for magic, ftype in magic_dict.items():
+        if file_start.startswith(magic):
+            return ftype
+    return b"application/txt"

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,6 @@ dependencies:
   - pyfaidx>=0.5.5.2
   - pysam>=0.15.3
   - defaults::python>=3.6
-  - python-magic
   - python-rapidjson>=0.8.0
   - pyyaml>=5.1.2
   - scikit-learn>=0.21.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ pytest
 pyfaidx
 scikit-learn>=0.17.0
 scipy>=1.0.0
-python-magic
 drmaa
 snakemake
 docutils!=0.13.1


### PR DESCRIPTION
Removes libmagic keeping the checks of the magic bits on the files that were provided by this library, this commit removes a dependency both on python and the OS given that python uses the underlying library which is not available in some container images.