### PR TITLE
Mikado can be installed directly with pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - conda env create -n env_name --file environment.yml
   - source activate env_name
   - conda install -y -c conda-forge -- pytest-cov codecov;
-  - conda install -c bioconda -c conda-forge -y stringtie scallop gmap star hisat2 prodigal blast diamond transdecoder gnuplot kallisto samtools gffread
+  - conda install -c bioconda -c conda-forge -y stringtie scallop gmap star hisat2 prodigal blast diamond transdecoder conda-forge::gnuplot kallisto samtools gffread
   - python setup.py develop;
 script:
   - pytest -m slow Mikado/tests/test_system_calls.py::SerialiseChecker::test_subprocess_multi_empty_orfs

--- a/Mikado/daijin/assemble.smk
+++ b/Mikado/daijin/assemble.smk
@@ -510,7 +510,7 @@ rule gmap_index:
     log: os.path.join(ALIGN_DIR, "logs", "gmap", "index.log")
     message: "Indexing genome with gmap"
     conda: os.path.join(envdir, "gmap.yaml")
-    shell: "{params.load} gmap_build --dir={params.dir} --db={NAME} {input} > {log} 2>&1"
+    shell: "{params.load} gmap_build --dir={params.dir} -d {NAME} {input} > {log} 2>&1"
 
 
 rule gsnap_index:

--- a/Mikado/parsers/bed12.py
+++ b/Mikado/parsers/bed12.py
@@ -299,8 +299,8 @@ class BED12:
         self.score = 0
         self.strand = None
         self.rgb = ''
-        self.__block_sizes = np.zeros(1, dtype=np.integer)
-        self.__block_starts = np.zeros(1, dtype=np.integer)
+        self.__block_sizes = np.zeros(1, dtype=np.int_)
+        self.__block_starts = np.zeros(1, dtype=np.int_)
         self.__block_count = 1
         self.__invalid = None
         self.invalid_reason = None
@@ -1053,7 +1053,7 @@ class BED12:
 
     @start.setter
     def start(self, value):
-        if not isint(value) and not isinstance(value, np.integer):
+        if not isint(value) and not isinstance(value, np.int_):
             raise ValueError("Thick end must be an integer!")
         self.__start = fast_int(value)
         del self.invalid
@@ -1069,7 +1069,7 @@ class BED12:
 
     @end.setter
     def end(self, value):
-        if not isint(value) and not isinstance(value, np.integer):
+        if not isint(value) and not isinstance(value, np.int_):
             raise ValueError("Thick end must be an integer, not {}! Value: {}".format(type(value), value))
         self.__end = fast_int(value)
         del self.invalid
@@ -1085,7 +1085,7 @@ class BED12:
 
     @thick_start.setter
     def thick_start(self, value):
-        if not isint(value) and not isinstance(value, np.integer):
+        if not isint(value) and not isinstance(value, np.int_):
             raise ValueError("Thick end must be an integer!")
         self.__thick_start = fast_int(value)
         del self.invalid
@@ -1101,7 +1101,7 @@ class BED12:
 
     @thick_end.setter
     def thick_end(self, value):
-        if not isint(value) and not isinstance(value, np.integer):
+        if not isint(value) and not isinstance(value, np.int_):
             raise ValueError("Thick end must be an integer!")
         self.__thick_end = fast_int(value)
         del self.invalid
@@ -1146,7 +1146,7 @@ class BED12:
 
     @block_count.setter
     def block_count(self, value):
-        if not isint(value) and not isinstance(value, np.integer):
+        if not isint(value) and not isinstance(value, np.int_):
             raise ValueError("Thick end must be an integer!")
         self.__block_count = fast_int(value)
         del self.invalid
@@ -1158,14 +1158,14 @@ class BED12:
     @block_sizes.setter
     def block_sizes(self, sizes):
         sizes = np.array(sizes)
-        if not issubclass(sizes.dtype.type, np.integer):
+        if not issubclass(sizes.dtype.type, np.int_):
             raise TypeError("Block sizes should be integers!")
         self.__block_sizes = sizes
         del self.invalid
 
     @block_sizes.deleter
     def block_sizes(self):
-        self.__block_sizes = np.zeros(1, dtype=np.integer)
+        self.__block_sizes = np.zeros(1, dtype=np.int_)
         del self.invalid
 
     @property
@@ -1175,7 +1175,7 @@ class BED12:
     @block_starts.setter
     def block_starts(self, starts):
         starts = np.array(starts)
-        if not issubclass(starts.dtype.type, np.integer):
+        if not issubclass(starts.dtype.type, np.int_):
             raise TypeError("Block sizes should be integers! Dtype: {}; array: {}".format(
                 starts.dtype, starts
             ))
@@ -1184,7 +1184,7 @@ class BED12:
 
     @block_starts.deleter
     def block_starts(self):
-        self.__block_starts = np.zeros(1, dtype=np.integer)
+        self.__block_starts = np.zeros(1, dtype=np.int_)
         del self.invalid
 
     @property
@@ -1355,7 +1355,7 @@ class BED12:
             bsizes = np.flip(self.block_sizes)
             tStart, tEnd = self.block_sizes.sum() - tEnd, self.block_sizes.sum() - tStart
 
-        bstarts = np.concatenate([np.zeros(1, dtype=np.integer), bsizes[:-1].cumsum()])
+        bstarts = np.concatenate([np.zeros(1, dtype=np.int_), bsizes[:-1].cumsum()])
         # bstarts = [0]
         # for bs in bsizes[:-1]:
         #     bstarts.append(bs + bstarts[-1])

--- a/Mikado/transcripts/transcript_methods/printing.py
+++ b/Mikado/transcripts/transcript_methods/printing.py
@@ -375,9 +375,9 @@ def as_bed12(transcript, transcriptomic=False):
     bed12.block_count = transcript.exon_num
     bed12.block_sizes = [exon[1] - exon[0] + 1 for exon in transcript.exons]
     _introns = np.concatenate([np.array([intron[1] - intron[0] + 1 for intron in sorted(transcript.introns)],
-                                        dtype=np.integer),
-                               np.zeros(1, dtype=np.integer)])
-    bed12.block_starts = np.concatenate([np.zeros(1, dtype=np.integer),
+                                        dtype=np.int_),
+                               np.zeros(1, dtype=np.int_)])
+    bed12.block_starts = np.concatenate([np.zeros(1, dtype=np.int_),
                                          (bed12.block_sizes + _introns).cumsum()[:-1]], axis=0)
     assert bed12.block_starts[0] == 0, bed12.block_starts
     if transcriptomic:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools","wheel","cython","numpy","scipy"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Using PEP-517 & PEP-518 the installation of mikado can occur directly without any extra steps. A simple `pip install .` now works seamlessly.

Fixes mikado-315 Installation from pip fails

Signed-off-by: ljyanesm