### PR TITLE
Fix #314

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ script:
   - mikado pick --log $(pwd)/pick.20b.log --procs 2 --seed 20 --fasta Mikado/tests/chr5.fas.gz  --json-conf Mikado/tests/check_seed.yaml -od 20b Mikado/tests/check_seed.gtf  
   - mikado pick --log $(pwd)/pick.20c.log --procs 2 --seed 20 --fasta Mikado/tests/chr5.fas.gz  --json-conf Mikado/tests/check_seed.yaml -od 20c Mikado/tests/check_seed.gtf
   - mikado pick --log $(pwd)/pick.20d.log --procs 2 --seed 20 --fasta Mikado/tests/chr5.fas.gz  --json-conf Mikado/tests/check_seed.yaml -od 20d Mikado/tests/check_seed.gtf     
-  - mikado pick --log $(pwd)/pick.10.log --procs 2 --seed 10 --fasta Mikado/tests/chr5.fas.gz  --json-conf Mikado/tests/check_seed.yaml -od 10 Mikado/tests/check_seed.gtf
+  - mikado pick --log $(pwd)/pick.10.log --procs 2 --seed 1000 --fasta Mikado/tests/chr5.fas.gz  --json-conf Mikado/tests/check_seed.yaml -od 1000 Mikado/tests/check_seed.gtf
   - if [[ $(diff -q 20a 20b) || $(diff -q 20a 20c) || $(diff -q 20a 20d) ]]; then exit 1; fi
-  - if [[ ! $(diff -q 20a 10) ]]; then exit 1; fi
+  - if [[ ! $(diff -q 20a 1000) ]]; then exit 1; fi
 
 after_success:
   - codecov 

--- a/Mikado/configuration/configurator.py
+++ b/Mikado/configuration/configurator.py
@@ -24,6 +24,7 @@ from ..exceptions import InvalidJson, UnrecognizedRescaler
 from ..utilities import merge_dictionaries
 from ..utilities.log_utils import create_default_logger
 import numpy
+import random
 import toml
 try:
     from yaml import CSafeLoader as yLoader
@@ -645,14 +646,17 @@ def check_json(json_conf, simple=False, external_dict=None, logger=None):
 
     seed = json_conf.get("seed", None)
     if seed is None:
-        seed = numpy.random.randint(0, 2**32 - 1)
+        # seed = numpy.random.randint(0, 2**32 - 1)
+        seed = random.randint(0, 2**32 - 1)
         logger.info("Random seed: {}", seed)
         json_conf["seed"] = seed
 
     if seed is not None:
-        numpy.random.seed(seed % (2 ** 32 - 1))
+        # numpy.random.seed(seed % (2 ** 32 - 1))
+        random.seed(seed % (2 ** 32 - 1))
     else:
-        numpy.random.seed(None)
+        # numpy.random.seed(None)
+        random.seed(None)
 
     return json_conf
 
@@ -700,12 +704,15 @@ def to_json(string, simple=False, logger=None):
 
     seed = json_dict.get("seed", 0)
     if seed == 0:
-        seed = numpy.random.randint(1, 2 ** 32 - 1)
+        # seed = numpy.random.randint(1, 2 ** 32 - 1)
+        seed = random.randint(1, 2 ** 32 - 1)
         logger.info("Random seed: {}", seed)
 
     if seed != 0:
-        numpy.random.seed(seed % (2 ** 32 - 1))
+        # numpy.random.seed(seed % (2 ** 32 - 1))
+        random.seed(seed % (2 ** 32 - 1))
     else:
-        numpy.random.seed(None)
+        # numpy.random.seed(None)
+        random.seed(None)
 
     return json_dict

--- a/Mikado/loci/abstractlocus.py
+++ b/Mikado/loci/abstractlocus.py
@@ -27,6 +27,7 @@ if version_info.minor < 5:
 else:
     from collections import OrderedDict as SortedDict
 from fastnumbers import isfloat
+import random
 import rapidjson as json
 
 # I do not care that there are too many attributes: this IS a massive class!
@@ -437,11 +438,13 @@ class Abstractlocus(metaclass=abc.ABCMeta):
         # Choose one transcript randomly between those that have the maximum score
         if len(transcripts) == 1:
             return list(transcripts.keys())[0]
-        np.random.seed(self.json_conf["seed"])
+        # np.random.seed(self.json_conf["seed"])
+        random.seed(self.json_conf["seed"])
         max_score = max(transcripts.values(),
                         key=operator.attrgetter("score")).score
         valid = sorted([transc for transc in transcripts if transcripts[transc].score == max_score])
-        chosen = valid[numpy.random.choice(len(valid))]
+        # chosen = valid[numpy.random.choice(len(valid))]
+        chosen = valid[random.choice(range(len(valid)))]
         self.logger.debug("Chosen {chosen} out of {}".format(", ".join(valid), chosen=chosen))
         return chosen
 

--- a/Mikado/loci/locus.py
+++ b/Mikado/loci/locus.py
@@ -22,6 +22,7 @@ import io
 from pkg_resources import resource_stream
 import rapidjson as json
 import jsonschema
+import random
 
 
 with io.TextIOWrapper(resource_stream("Mikado.configuration",
@@ -426,7 +427,8 @@ class Locus(Abstractlocus):
                     elif self[couple[1]].score > self[couple[0]].score:
                         removal = couple[0]
                     else:
-                        removal = np.random.choice(sorted(couple))
+                        # removal = np.random.choice(sorted(couple))
+                        removal = random.choice(sorted(couple))
                 except (TypeError, ValueError):
                     raise ValueError((couple, self[couple[0]].score, self[couple[1]].score))
                 finally:

--- a/Mikado/loci/superlocus.py
+++ b/Mikado/loci/superlocus.py
@@ -40,6 +40,7 @@ from .excluded import Excluded
 from typing import Union
 from ..utilities.intervaltree import Interval, IntervalTree
 from itertools import combinations
+import random
 
 # The number of attributes is something I need
 # pylint: disable=too-many-instance-attributes
@@ -843,7 +844,8 @@ class Superlocus(Abstractlocus):
                     elif self.transcripts[current_id].is_reference:
                         to_remove.add(transcript.id)
                     else:
-                        chosen = np.random.choice(sorted([current_id, transcript.id]))
+                        # chosen = np.random.choice(sorted([current_id, transcript.id]))
+                        chosen = random.choice(sorted([current_id, transcript.id]))
                         if current_id == chosen:
                             to_remove.add(transcript.id)
                         else:

--- a/Mikado/parsers/bed12.py
+++ b/Mikado/parsers/bed12.py
@@ -32,6 +32,7 @@ from ..utilities.log_utils import create_null_logger
 import pyfaidx
 import zlib
 import numpy as np
+import random
 
 
 backup_valid_letters = set(_ambiguous_dna_letters.upper() + _ambiguous_rna_letters.upper())
@@ -1479,7 +1480,8 @@ class Bed12Parser(Parser):
         if isinstance(fasta_index, dict):
             # check that this is a bona fide dictionary ...
             assert isinstance(
-                fasta_index[numpy.random.choice(fasta_index.keys(), 1)],
+                fasta_index[random.choice(fasta_index.keys())],
+                # fasta_index[numpy.random.choice(fasta_index.keys(), 1)],
                 Bio.SeqRecord.SeqRecord)
         elif fasta_index is not None:
             if isinstance(fasta_index, (str, bytes)):
@@ -1639,7 +1641,8 @@ class Bed12ParseWrapper(mp.Process):
         if isinstance(fasta_index, dict):
             # check that this is a bona fide dictionary ...
             assert isinstance(
-                fasta_index[numpy.random.choice(fasta_index.keys(), 1)],
+                # fasta_index[numpy.random.choice(fasta_index.keys(), 1)],
+                fasta_index[random.choice(fasta_index.keys())],
                 Bio.SeqRecord.SeqRecord)
         elif fasta_index is not None:
             if isinstance(fasta_index, (str, bytes)):

--- a/Mikado/picking/picker.py
+++ b/Mikado/picking/picker.py
@@ -11,7 +11,7 @@ import csv
 import os
 import shutil
 import tempfile
-from math import floor
+import random
 import logging
 from logging import handlers as logging_handlers
 import functools
@@ -41,7 +41,6 @@ from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier
 import pickle
 import warnings
 import pyfaidx
-import numpy
 import sqlite3
 import msgpack
 from fastnumbers import fast_int
@@ -106,9 +105,11 @@ class Picker:
         # self.setup_logger()
         self.logger.info("Random seed: %s", self.json_conf["seed"])
         if self.json_conf["seed"] is not None:
-            numpy.random.seed((self.json_conf["seed"]) % (2 ** 32 - 1))
+            # numpy.random.seed((self.json_conf["seed"]) % (2 ** 32 - 1))
+            random.seed((self.json_conf["seed"]) % (2 ** 32 - 1))
         else:
-            numpy.random.seed(None)
+            # numpy.random.seed(None)
+            random.seed(None)
         self.logger.debug("Multiprocessing method: %s", self.json_conf["multiprocessing_method"])
 
         # pylint: enable=no-member

--- a/Mikado/preparation/annotation_parser.py
+++ b/Mikado/preparation/annotation_parser.py
@@ -12,9 +12,9 @@ except ImportError:
     import json
 import sqlite3
 import os
-import numpy
 from ..transcripts import Transcript
 from operator import itemgetter
+import random
 
 
 __author__ = 'Luca Venturini'
@@ -34,9 +34,11 @@ class AnnotationParser(multiprocessing.Process):
 
         super().__init__()
         if seed is not None:
-            numpy.random.seed(seed % (2 ** 32 - 1))
+            # numpy.random.seed(seed % (2 ** 32 - 1))
+            random.seed(seed % (2 ** 32 - 1))
         else:
-            numpy.random.seed(None)
+            # numpy.random.seed(None)
+            random.seed(None)
 
         self.submission_queue = submission_queue
         self.min_length = min_length

--- a/Mikado/preparation/checking.py
+++ b/Mikado/preparation/checking.py
@@ -16,6 +16,7 @@ import sys
 import numpy
 import rapidjson as json
 import operator
+import random
 
 
 __author__ = 'Luca Venturini'
@@ -161,9 +162,11 @@ class CheckingProcess(multiprocessing.Process):
         self.__identifier = ""
         self.__set_identifier(identifier)
         if seed is not None:
-            numpy.random.seed(seed % (2 ** 32 - 1))
+            # numpy.random.seed(seed % (2 ** 32 - 1))
+            random.seed(seed % (2 ** 32 - 1))
         else:
-            numpy.random.seed(None)
+            # numpy.random.seed(None)
+            random.seed(None)
         # self.strand_specific = strand_specific
         self.__canonical = []
         self.__set_canonical(canonical_splices)

--- a/Mikado/preparation/prepare.py
+++ b/Mikado/preparation/prepare.py
@@ -22,6 +22,7 @@ import sqlite3
 import pysam
 import numpy as np
 import rapidjson as json
+import random
 
 
 __author__ = 'Luca Venturini'
@@ -101,7 +102,9 @@ def _select_transcript(is_reference, keep_redundant, score, other, start, end):
         elif (is_reference is True and other["is_reference"] is False) or (score > other["score"]):
             to_keep = True
         else:
-            to_keep, other_to_keep = np.random.permutation([True, False])
+            # to_keep, other_to_keep = np.random.permutation([True, False])
+            to_keep = random.choice([True, False])
+            other_to_keep = not to_keep
     else:
         if (is_reference is False and other["is_reference"] is True) or (score < other["score"]):
             other_to_keep = True
@@ -239,7 +242,8 @@ def store_transcripts(shelf_stacks, logger, seed=None):
         except sqlite3.OperationalError as exc:
             raise sqlite3.OperationalError("dump not found in {}; excecption: {}".format(shelf_name, exc))
 
-    np.random.seed(seed)
+    # np.random.seed(seed)
+    random.seed(seed)
     for chrom in sorted(transcripts.keys()):
         logger.debug("Starting with %s (%d positions)",
                      chrom,
@@ -313,7 +317,8 @@ def perform_check(keys, shelve_stacks, args, logger):
         # submission_queue = multiprocessing.JoinableQueue(-1)
 
         batches = list(enumerate(keys, 1))
-        np.random.shuffle(batches)
+        # np.random.shuffle(batches)
+        random.shuffle(batches)
         kwargs = {
             "fasta_out": os.path.basename(args.json_conf["prepare"]["files"]["out_fasta"].name),
             "gtf_out": os.path.basename(args.json_conf["prepare"]["files"]["out"].name),

--- a/Mikado/subprograms/pick.py
+++ b/Mikado/subprograms/pick.py
@@ -9,7 +9,7 @@ import os
 from ..picking import Picker
 from ..configuration.configurator import to_json, check_json
 from ..utilities.log_utils import create_default_logger, create_null_logger
-import numpy
+import random
 from ..utilities import to_region
 from ..utilities.intervaltree import IntervalTree, Interval
 
@@ -57,9 +57,11 @@ def check_run_options(args, logger=create_null_logger()):
 
     if args.seed is not None:
         args.json_conf["seed"] = args.seed
-        numpy.random.seed(args.seed % (2 ** 32 - 1))
+        # numpy.random.seed(args.seed % (2 ** 32 - 1))
+        random.seed(args.seed % (2 ** 32 - 1))
     else:
-        numpy.random.seed(None)
+        # numpy.random.seed(None)
+        random.seed(None)
 
     if args.no_cds is not False:
         args.json_conf["pick"]["run_options"]["exclude_cds"] = True

--- a/Mikado/subprograms/prepare.py
+++ b/Mikado/subprograms/prepare.py
@@ -15,7 +15,7 @@ from ..utilities.log_utils import formatter
 from ..preparation.prepare import prepare
 from ..configuration.configurator import to_json, check_json
 from Mikado.exceptions import InvalidJson
-import numpy
+import random
 from collections import Counter
 
 
@@ -136,9 +136,11 @@ def setup(args):
 
     if args.seed is not None:
         args.json_conf["seed"] = args.seed
-        numpy.random.seed(args.seed % (2 ** 32 - 1))
+        # numpy.random.seed(args.seed % (2 ** 32 - 1))
+        random.seed(args.seed % (2 ** 32 - 1))
     else:
-        numpy.random.seed(None)
+        # numpy.random.seed(None)
+        random.seed(None)
 
     args.json_conf = parse_prepare_options(args, args.json_conf)
 

--- a/Mikado/subprograms/serialise.py
+++ b/Mikado/subprograms/serialise.py
@@ -22,9 +22,9 @@ from ..serializers import orf, blast_serializer, junction
 from ..serializers import external
 from ..exceptions import InvalidJson
 import pyfaidx
-import numpy
 from ..exceptions import InvalidSerialization
 from ..serializers.blast_serializer.tabular_utils import blast_keys
+import random
 
 
 __author__ = 'Luca Venturini'
@@ -218,9 +218,11 @@ def setup(args):
 
     if args.seed is not None:
         args.json_conf["seed"] = args.seed
-        numpy.random.seed((args.seed) % (2 ** 32 - 1))
+        # numpy.random.seed((args.seed) % (2 ** 32 - 1))
+        random.seed((args.seed) % (2 ** 32 - 1))
     else:
-        numpy.random.seed(None)
+        # numpy.random.seed(None)
+        random.seed(None)
 
     if args.output_dir is not None:
         args.json_conf["serialise"]["files"]["output_dir"] = args.output_dir

--- a/Mikado/tests/test_system_calls.py
+++ b/Mikado/tests/test_system_calls.py
@@ -391,8 +391,8 @@ class PrepareCheck(unittest.TestCase):
 
                 with self.assertRaises(SystemExit) as exi:
                     prepare_launcher(args)
-                # self.assertTrue(os.path.exists(folder.name))
-                # self.assertTrue(os.path.isdir(folder.name))
+                self.assertTrue(os.path.exists(folder.name))
+                self.assertTrue(os.path.isdir(folder.name))
                 self.assertEqual(exi.exception.code, 0)
                 self.assertTrue(os.path.exists(os.path.join(folder.name,
                                                             "mikado_prepared.fasta")),
@@ -401,15 +401,15 @@ class PrepareCheck(unittest.TestCase):
                 fa = pyfaidx.Fasta(os.path.join(folder.name,
                                                 "mikado_prepared.fasta"))
                 logged = [_ for _ in open(args.json_conf["prepare"]["files"]["log"])]
-                self.assertTrue("AT5G01530.1" in fa.keys())
-                self.assertFalse("AT5G01530.2" in fa.keys())
+                self.assertFalse("AT5G01530.1" in fa.keys())
+                self.assertTrue("AT5G01530.2" in fa.keys())
                 if b is True:
                     self.assertEqual(len(fa.keys()), 4)
-                    self.assertEqual(sorted(fa.keys()), sorted(["AT5G01530."+str(_) for _ in [0, 1, 3, 4]]))
+                    self.assertEqual(sorted(fa.keys()), sorted(["AT5G01530."+str(_) for _ in [0, 2, 3, 4]]))
                 else:
                     self.assertEqual(len(fa.keys()), 3, (fa.keys(), logged))
                     self.assertIn("AT5G01530.0", fa.keys())
-
+                    self.assertIn("AT5G01530.2", fa.keys())
                     self.assertNotIn("AT5G01530.3", fa.keys())
                     self.assertIn("AT5G01530.4", fa.keys())
                 gtf_file = os.path.join(folder.name, "mikado_prepared.gtf")
@@ -442,10 +442,7 @@ class PrepareCheck(unittest.TestCase):
                             self.assertEqual(transcript.is_complete,
                                              transcript.has_start_codon and transcript.has_stop_codon)
                     # self.assertIn("AT5G01530.3", transcripts)
-                    if "AT5G01530.1" in transcripts:
-                        a5 = transcripts["AT5G01530.1"]
-                    else:
-                        a5 = transcripts["AT5G01530.2"]
+                    a5 = transcripts["AT5G01530.2"]
                     self.assertTrue(a5.is_coding)
                     self.assertIn("has_start_codon", a5.attributes)
                     self.assertIn("has_stop_codon", a5.attributes)


### PR DESCRIPTION
This PR fixes issue #314. The reproducibility of Mikado was inficiated by using `numpy.random.seed` rather than the built-in `random.seed`. Briefly, to obtain a deterministic `numpy` seed from an initial number one has to jump through many hoops (see [here](https://github.com/scipy/scipy/blob/0765482e9a7cd7a7975f6161d2ab91994762ac8e/scipy/_lib/_util.py#L191)). The `random` seed is much simpler and `random` is perfectly adequate for the simple needs of `mikado`.