### PR TITLE
Issue 346 compare usage

### DIFF
--- a/Mikado/parsers/GFF.py
+++ b/Mikado/parsers/GFF.py
@@ -46,19 +46,17 @@ class GffLine(GFAnnotation):
         infolist = self._attribute_pattern.findall(self._attr.rstrip().rstrip(";"))
         attribute_order = [key for key, val in infolist if key not in ("Parent", "parent", "id", "ID", "Id")]
         attributes = dict((key, _attribute_definition(val)) for key, val in infolist)
+
         if "Parent" in attributes:
-            self.parent = str(attributes["Parent"])
+            self.parent = attributes["Parent"]
         elif "parent" in attributes:
-            self.parent = str(attributes["parent"])
+            self.parent = attributes["parent"]
 
         if "ID" in attributes:
-            attributes["ID"] = str(attributes["ID"])
             self.id = attributes["ID"]
         elif "id" in attributes:
-            attributes["id"] = str(attributes["id"])
             self.id = attributes["id"]
         elif "Id" in attributes:
-            attributes["Id"] = str(attributes["Id"])
             self.id = attributes["Id"]
 
         self.attributes.update(attributes)

--- a/Mikado/parsers/GFF.py
+++ b/Mikado/parsers/GFF.py
@@ -47,16 +47,23 @@ class GffLine(GFAnnotation):
         attribute_order = [key for key, val in infolist if key not in ("Parent", "parent", "id", "ID", "Id")]
         attributes = dict((key, _attribute_definition(val)) for key, val in infolist)
 
+        # Ensure that the "parent" attribute is a string
         if "Parent" in attributes:
+            attributes["Parent"] = str(attributes["Parent"])
             self.parent = attributes["Parent"]
         elif "parent" in attributes:
+            attributes["parent"] = str(attributes["parent"])
             self.parent = attributes["parent"]
 
+        # Ensure that the "ID" attribute is a string
         if "ID" in attributes:
+            attributes["ID"] = str(attributes["ID"])
             self.id = attributes["ID"]
         elif "id" in attributes:
+            attributes["id"] = str(attributes["id"])
             self.id = attributes["id"]
         elif "Id" in attributes:
+            attributes["Id"] = str(attributes["Id"])
             self.id = attributes["Id"]
 
         self.attributes.update(attributes)

--- a/Mikado/parsers/gfannotation.py
+++ b/Mikado/parsers/gfannotation.py
@@ -16,23 +16,20 @@ __author__ = 'Luca Venturini'
 [intern(_) for _ in ["+", "-", "?", "true", "True", "false", "False"]]
 
 
-def last(value):
-    if value in ("true", "True"):
-        value = True
-    elif value in ("False", "false"):
-        value = False
-    return value
-
-
 def _attribute_definition(val):
     try:
-        val = int(val)
+        val = float(val)
+        if val.is_integer():
+            return int(val)
+        return val
     except (ValueError, TypeError):
-        try:
-            val = float(val)
-        except (ValueError, TypeError):
-            val = last(val)
-    return val
+        if val.lower() in ("true", "false"):
+            val = val.capitalize()
+            if val == "True":
+                return True
+            else:
+                return False
+        return val
 
 
 # This class has exactly how many attributes I need it to have

--- a/Mikado/scales/assignment/assigner.py
+++ b/Mikado/scales/assignment/assigner.py
@@ -341,7 +341,6 @@ class Assigner:
                 self.print_tmap(None)
                 return None
         except InvalidTranscript as err:
-            #         args.queue.put_nowait("mock")
             self.logger.warning("Invalid transcript: %s", prediction.id)
             self.logger.warning("Error message: %s", err)
             # self.done += 1
@@ -688,7 +687,6 @@ class Assigner:
         # Ignore non-coding RNAs if we are interested in protein-coding transcripts only
         # noinspection PyUnresolvedReferences
         if self.args.protein_coding is True and prediction.combined_cds_length == 0:
-            #         args.queue.put_nowait("mock")
             self.logger.debug("No CDS for %s. Ignoring.", prediction.id)
             # self.done += 1
             self.print_tmap(None)

--- a/Mikado/scales/assignment/assigner.py
+++ b/Mikado/scales/assignment/assigner.py
@@ -768,7 +768,9 @@ class Assigner:
 
         self.print_refmap()
         self.stat_calculator.print_stats()
+        self.logger.info("Finished printing final stats")
         self.tmap_out.close()
+        self.logger.info("Closed output files")
 
     def calc_and_store_compare(self, prediction: Transcript, reference: Transcript, fuzzymatch=0) -> ResultStorer:
         """Thin layer around the calc_and_store_compare class method.

--- a/Mikado/scales/assignment/assigner.py
+++ b/Mikado/scales/assignment/assigner.py
@@ -162,10 +162,6 @@ class Assigner:
                 self.tmap_out = gzip.open("{0}.tmap.gz".format(args.out), 'wt')
             self.tmap_rower = csv.DictWriter(self.tmap_out, ResultStorer.__slots__, delimiter="\t")
             self.tmap_rower.writeheader()
-            self.db, self._connection, self._cursor = [None] * 3
-        else:
-            self.db = tempfile.NamedTemporaryFile(prefix=".compare", suffix=".db", dir="..", delete=False,
-                                                  mode="wb")
 
         self.gene_matches = collections.defaultdict(dict)
         self.done = 0

--- a/Mikado/scales/assignment/distributed.py
+++ b/Mikado/scales/assignment/distributed.py
@@ -96,4 +96,7 @@ class FinalAssigner(mp.Process):
                 self.assigner.load_result(tmap_row[1], tmap_row[2])
             self.queue.task_done()
 
+        self.queue.join()
         self.assigner.finish()
+        self.assigner.logger.info("Finished everything, shutting down")
+        return

--- a/Mikado/scales/prediction_parsers/__init__.py
+++ b/Mikado/scales/prediction_parsers/__init__.py
@@ -68,7 +68,7 @@ def parse_prediction(args, index, queue_logger):
         nargs = Namespace(default=False, **dargs)
         nargs.self = doself
         procs = [Assigners(index, nargs, queue, returnqueue, log_queue, counter)
-                 for counter in range(1, args.processes)]
+                 for counter in range(args.processes)]
         [proc.start() for proc in procs]
         final_proc = FinalAssigner(index, nargs, returnqueue, log_queue=log_queue, nprocs=len(procs))
         final_proc.start()

--- a/Mikado/scales/prediction_parsers/parse_bam_prediction.py
+++ b/Mikado/scales/prediction_parsers/parse_bam_prediction.py
@@ -3,27 +3,19 @@ from ...parsers.bam_parser import BamParser
 from ...exceptions import InvalidTranscript
 from ...transcripts import Transcript
 import functools
-from .transmission import transmit_transcript
 
 
-def parse_prediction_bam(args, queue, queue_logger):
+def parse_prediction_bam(args, queue_logger):
     constructor = functools.partial(Transcript, logger=queue_logger, trust_orf=True, accept_undefined_multi=True)
 
     transcript = None
-    done = 0
-    lastdone = 1
-    __found_with_orf = set()
     name_counter = collections.Counter()  # This is needed for BAMs
     invalids = set()
-    rows = []
     if args.prediction.__annot_type__ == BamParser.__annot_type__:
         for row in args.prediction:
             if row.is_unmapped is True:
                 continue
-            rows, done, lastdone, __found_with_orf = transmit_transcript(
-                transcript=transcript, done=done, lastdone=lastdone,
-                rows=rows, __found_with_orf=__found_with_orf,
-                queue=queue, queue_logger=queue_logger)
+            yield transcript
             try:
                 transcript = constructor(row)
             except (InvalidTranscript, AssertionError, TypeError, ValueError):
@@ -37,9 +29,4 @@ def parse_prediction_bam(args, queue, queue_logger):
                 name = row.query_name
             transcript.id = transcript.name = transcript.alias = name
             transcript.parent = transcript.attributes["gene_id"] = "{0}.gene".format(name)
-    rows, done, lastdone, __found_with_orf = transmit_transcript(
-        transcript=transcript, done=done, lastdone=lastdone,
-        rows=rows, __found_with_orf=__found_with_orf,
-        queue=queue, queue_logger=queue_logger, send_all=True)
-
-    return done, lastdone
+    yield transcript

--- a/Mikado/scales/prediction_parsers/parse_bam_prediction.py
+++ b/Mikado/scales/prediction_parsers/parse_bam_prediction.py
@@ -1,9 +1,13 @@
 import collections
 from ...parsers.bam_parser import BamParser
 from ...exceptions import InvalidTranscript
+from ...transcripts import Transcript
+import functools
+from .transmission import transmit_transcript
 
 
-def parse_prediction_bam(args, queue_logger, transmit_wrapper, constructor):
+def parse_prediction_bam(args, queue, queue_logger):
+    constructor = functools.partial(Transcript, logger=queue_logger, trust_orf=True, accept_undefined_multi=True)
 
     transcript = None
     done = 0
@@ -11,16 +15,17 @@ def parse_prediction_bam(args, queue_logger, transmit_wrapper, constructor):
     __found_with_orf = set()
     name_counter = collections.Counter()  # This is needed for BAMs
     invalids = set()
+    rows = []
     if args.prediction.__annot_type__ == BamParser.__annot_type__:
         for row in args.prediction:
             if row.is_unmapped is True:
                 continue
-            done, lastdone, __found_with_orf = transmit_wrapper(transcript=transcript,
-                                                                done=done,
-                                                                lastdone=lastdone,
-                                                                __found_with_orf=__found_with_orf)
+            rows, done, lastdone, __found_with_orf = transmit_transcript(
+                transcript=transcript, done=done, lastdone=lastdone,
+                rows=rows, __found_with_orf=__found_with_orf,
+                queue=queue, queue_logger=queue_logger)
             try:
-                transcript = constructor(row, accept_undefined_multi=True, trust_orf=True)
+                transcript = constructor(row)
             except (InvalidTranscript, AssertionError, TypeError, ValueError):
                 queue_logger.warning("Row %s is invalid, skipping.", row)
                 transcript = None
@@ -32,10 +37,9 @@ def parse_prediction_bam(args, queue_logger, transmit_wrapper, constructor):
                 name = row.query_name
             transcript.id = transcript.name = transcript.alias = name
             transcript.parent = transcript.attributes["gene_id"] = "{0}.gene".format(name)
-    done, lastdone, __found_with_orf = transmit_wrapper(
-        transcript=transcript,
-        done=done,
-        lastdone=lastdone,
-        __found_with_orf=__found_with_orf)
+    rows, done, lastdone, __found_with_orf = transmit_transcript(
+        transcript=transcript, done=done, lastdone=lastdone,
+        rows=rows, __found_with_orf=__found_with_orf,
+        queue=queue, queue_logger=queue_logger, send_all=True)
 
     return done, lastdone

--- a/Mikado/scales/prediction_parsers/parse_bed12.py
+++ b/Mikado/scales/prediction_parsers/parse_bed12.py
@@ -1,26 +1,18 @@
 from ...exceptions import InvalidTranscript
 from ...transcripts import Transcript
 import functools
-from .transmission import transmit_transcript, send_transcripts
 
 
-def parse_prediction_bed12(args, queue, queue_logger):
+def parse_prediction_bed12(args, queue_logger):
     """"""
 
     constructor = functools.partial(Transcript, logger=queue_logger, trust_orf=True, accept_undefined_multi=True)
     transcript = None
-    done = 0
-    lastdone = 1
     invalids = set()
-    __found_with_orf = set()
-    rows = []
     for row in args.prediction:
         if row.header is True:
             continue
-        rows, done, lastdone, __found_with_orf = transmit_transcript(
-            transcript=transcript, done=done, lastdone=lastdone,
-            rows=rows, __found_with_orf=__found_with_orf,
-            queue=queue, queue_logger=queue_logger)
+        yield transcript
         try:
             transcript = constructor(row)
         except (InvalidTranscript, AssertionError, TypeError, ValueError):
@@ -30,9 +22,4 @@ def parse_prediction_bed12(args, queue, queue_logger):
             continue
         transcript.parent = transcript.id
 
-    rows, done, lastdone, __found_with_orf = transmit_transcript(
-        transcript=transcript, done=done, lastdone=lastdone,
-        rows=rows, __found_with_orf=__found_with_orf,
-        queue=queue, queue_logger=queue_logger, send_all=True)
-
-    return done, lastdone
+    yield transcript

--- a/Mikado/scales/prediction_parsers/parse_bed12.py
+++ b/Mikado/scales/prediction_parsers/parse_bed12.py
@@ -1,21 +1,26 @@
 from ...exceptions import InvalidTranscript
+from ...transcripts import Transcript
+import functools
+from .transmission import transmit_transcript, send_transcripts
 
 
-def parse_prediction_bed12(args, queue_logger, transmit_wrapper, constructor):
+def parse_prediction_bed12(args, queue, queue_logger):
     """"""
 
+    constructor = functools.partial(Transcript, logger=queue_logger, trust_orf=True, accept_undefined_multi=True)
     transcript = None
     done = 0
     lastdone = 1
     invalids = set()
     __found_with_orf = set()
+    rows = []
     for row in args.prediction:
         if row.header is True:
             continue
-        done, lastdone, __found_with_orf = transmit_wrapper(transcript=transcript,
-                                                            done=done,
-                                                            lastdone=lastdone,
-                                                            __found_with_orf=__found_with_orf)
+        rows, done, lastdone, __found_with_orf = transmit_transcript(
+            transcript=transcript, done=done, lastdone=lastdone,
+            rows=rows, __found_with_orf=__found_with_orf,
+            queue=queue, queue_logger=queue_logger)
         try:
             transcript = constructor(row)
         except (InvalidTranscript, AssertionError, TypeError, ValueError):
@@ -25,8 +30,9 @@ def parse_prediction_bed12(args, queue_logger, transmit_wrapper, constructor):
             continue
         transcript.parent = transcript.id
 
-    done, lastdone, __found_with_orf = transmit_wrapper(transcript=transcript,
-                                                        done=done,
-                                                        lastdone=lastdone,
-                                                        __found_with_orf=__found_with_orf)
+    rows, done, lastdone, __found_with_orf = transmit_transcript(
+        transcript=transcript, done=done, lastdone=lastdone,
+        rows=rows, __found_with_orf=__found_with_orf,
+        queue=queue, queue_logger=queue_logger, send_all=True)
+
     return done, lastdone

--- a/Mikado/scales/prediction_parsers/parse_gff3_prediction.py
+++ b/Mikado/scales/prediction_parsers/parse_gff3_prediction.py
@@ -3,7 +3,7 @@ from ...transcripts import Gene
 from ...transcripts import Transcript
 
 
-def parse_prediction_gff3(args, queue, queue_logger):
+def parse_prediction_gff3(args, queue_logger):
     """Method to parse GFF files. This will use the Gene, rather than Transcript, class."""
 
     gene = None

--- a/Mikado/scales/prediction_parsers/parse_gtf_prediction.py
+++ b/Mikado/scales/prediction_parsers/parse_gtf_prediction.py
@@ -1,23 +1,28 @@
 from ...exceptions import InvalidTranscript
+from ...transcripts import Transcript
+import functools
+from .transmission import transmit_transcript
 
 
-def parse_prediction_gtf(args, queue_logger, transmit_wrapper, constructor):
+def parse_prediction_gtf(args, queue, queue_logger):
     """Method to parse GTF files."""
     invalids = set()
     done = 0
     lastdone = 1
     transcript = None
     __found_with_orf = set()
+    constructor = functools.partial(Transcript, logger=queue_logger, trust_orf=True, accept_undefined_multi=True)
+    rows = []
 
     for row in args.prediction:
         if row.header is True:
             continue
         if row.is_transcript is True:
             if transcript is not None:
-                done, lastdone, __found_with_orf = transmit_wrapper(
-                    transcript=transcript,
-                    __found_with_orf=__found_with_orf,
-                    done=done, lastdone=lastdone)
+                rows, done, lastdone, __found_with_orf = transmit_transcript(
+                    transcript=transcript, done=done, lastdone=lastdone,
+                    rows=rows, __found_with_orf=__found_with_orf,
+                    queue=queue, queue_logger=queue_logger)
             try:
                 transcript = constructor(row)
             except (InvalidTranscript, AssertionError, TypeError, ValueError):
@@ -31,11 +36,10 @@ def parse_prediction_gtf(args, queue_logger, transmit_wrapper, constructor):
                 # Skip children of invalid things
                 continue
             elif transcript is None or (transcript is not None and transcript.id != row.transcript):
-                done, lastdone, __found_with_orf = transmit_wrapper(
-                    transcript=transcript,
-                    __found_with_orf=__found_with_orf,
-                    done=done,
-                    lastdone=lastdone)
+                rows, done, lastdone, __found_with_orf = transmit_transcript(
+                    transcript=transcript, done=done, lastdone=lastdone,
+                    rows=rows, __found_with_orf=__found_with_orf,
+                    queue=queue, queue_logger=queue_logger)
                 queue_logger.debug("New transcript: %s", row.transcript)
                 transcript = constructor(row)
                 transcript.add_exon(row)
@@ -45,9 +49,9 @@ def parse_prediction_gtf(args, queue_logger, transmit_wrapper, constructor):
                 raise TypeError("Unmatched exon: {}".format(row))
         else:
             queue_logger.debug("Skipped row: {}".format(row))
-    done, lastdone, __found_with_orf = transmit_wrapper(
-        transcript=transcript,
-        done=done,
-        lastdone=lastdone,
-        __found_with_orf=__found_with_orf)
+
+    rows, done, lastdone, __found_with_orf = transmit_transcript(
+        transcript=transcript, done=done, lastdone=lastdone,
+        rows=rows, __found_with_orf=__found_with_orf,
+        queue=queue, queue_logger=queue_logger, send_all=True)
     return done, lastdone

--- a/Mikado/scales/prediction_parsers/transmission.py
+++ b/Mikado/scales/prediction_parsers/transmission.py
@@ -31,10 +31,10 @@ def get_best_result(transcript, assigner_instance: Assigner):
 orf_pattern = re.compile(r"\.orf[0-9]+$", re.IGNORECASE)
 
 
-def transmit_transcript(transcript: Transcript, done: int, lastdone: int,
+def transmit_transcript(transcript: Union[None,Transcript], done: int, lastdone: int,
                          rows: list, queue: Queue,
                          queue_logger: Logger,
-                         __found_with_orf: set, send_all=False) -> [list, int, int, int]:
+                         __found_with_orf: set, send_all=False):
 
     if transcript is not None:
         if orf_pattern.search(transcript.id):

--- a/Mikado/transcripts/transcript.py
+++ b/Mikado/transcripts/transcript.py
@@ -2186,8 +2186,7 @@ class Transcript:
             raise TypeError("Invalid value for combined CDS: {0}".format(combined))
 
         if len(combined) > 0:
-            ar = np.array(list(zip(*combined)))
-            self.__combined_cds_length = int(np.subtract(ar[1], ar[0] - 1).sum())
+            self.__combined_cds_length = sum([_[1] - _[0] + 1 for _ in combined])
         else:
             self.__combined_cds_length = 0
 
@@ -2506,8 +2505,7 @@ index {3}, internal ORFs: {4}".format(
     combined_utr_fraction.rtype = "float"
 
     def __calculate_cdna_length(self):
-        ar = np.array(list(zip(*self.exons)))
-        self.__cdna_length = int(np.subtract(ar[1], ar[0] - 1).sum())
+        self.__cdna_length = int(sum([_[1] - _[0] + 1 for _ in self.exons]))
 
     @Metric
     def cdna_length(self):


### PR DESCRIPTION
Changes:

- faster GFF/GTF parsing by improving the `_attribute_definition` function
- faster `cdna_length` property: numpy in this case was a drag
- simplified the parsing in `scales.parse_prediction`
- limited size of the queues, with improvements on memory (maximum 100 items in the queue)
- batch submission of transcripts for prediction (up to 1000 at a time), not on-line
- proper scaling up starting with two processes