### PR TITLE
HSP uniqueness could fail in rare cases

### DIFF
--- a/Mikado/serializers/blast_serializer/hsp.py
+++ b/Mikado/serializers/blast_serializer/hsp.py
@@ -109,7 +109,7 @@ class Hsp(DBBASE):
                        "counter", "query_id", "target_id", unique=True)
     uni_constraint = UniqueConstraint("query_id", "target_id",
                                       "query_hsp_start", "query_hsp_end",
-                                      "target_hsp_start", "target_hsp_end")
+                                      "target_hsp_start", "target_hsp_end", "hsp_evalue")
 
     __table_args__ = (pk_constraint, query_index, target_index, combined_index, hsp_evalue_index, uni_constraint)
 


### PR DESCRIPTION
Add evalue to uniqueness constraint to prevent rare cases where the existing keys were not enough to guarantee uniqueness.

Users could also filter input hits to a lower evalue and prevent this issue.

Fix for #422 