### PR TITLE
Update requirements.txt

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -30,8 +30,8 @@ dependencies:
   - wheel
   - pytest>=5.4.1
   - python-rapidjson>=1.0
-  - marshmallow>=3.1.0
-  - marshmallow-dataclass>=8.3.1
+  - marshmallow==3.14.1
+  - marshmallow-dataclass==8.5.3
   - typeguard>=2.9.1
   - conda-forge::toml>=0.10.0
   - bioconda::pyfaidx>=0.5.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,6 @@ python-rapidjson>=1.0.0
 toml>=0.10.0
 pyfaidx>=0.5.8
 dataclasses; python_version < '3.7'
-marshmallow==3.15.0
-marshmallow-dataclass==8.4.1
+marshmallow==3.14.1
+marshmallow-dataclass==8.5.3
 typeguard  # Necessary for mashmallow apparently

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,6 @@ python-rapidjson>=1.0.0
 toml>=0.10.0
 pyfaidx>=0.5.8
 dataclasses; python_version < '3.7'
-marshmallow
-marshmallow-dataclass
+marshmallow==3.15.0
+marshmallow-dataclass==8.4.1
 typeguard  # Necessary for mashmallow apparently


### PR DESCRIPTION
Fixes marshmallow dependency versions

More recent versions of marshmallow are currently incompatible with Mikado.

Potentially fixes #431